### PR TITLE
chore: hoist browserlist to external

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "prebuild": "rimraf dist/ && node patch.js",
-    "build": "ncc build src/index.js -o dist --minify --external postcss --external caniuse-lite --external caniuse-lite/dist/unpacker/feature --external caniuse-lite/dist/unpacker/region --external caniuse-lite/dist/unpacker/agents",
+    "build": "ncc build src/index.js -o dist --minify --external browserslist --external postcss --external caniuse-lite --external caniuse-lite/dist/unpacker/feature --external caniuse-lite/dist/unpacker/region --external caniuse-lite/dist/unpacker/agents",
     "test": "jest",
     "prepublishOnly": "yarn build && yarn test",
     "semantic-release": "semantic-release",
@@ -33,6 +33,7 @@
     "semantic-release": "^19.0.2"
   },
   "dependencies": {
+    "browserslist": "^4.21.5",
     "caniuse-lite": "^1.0.30001314"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1445,6 +1445,16 @@ browserslist@^4.0.0, browserslist@^4.16.6, browserslist@^4.17.5:
     node-releases "^2.0.2"
     picocolors "^1.0.0"
 
+browserslist@^4.21.5:
+  version "4.21.5"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.5.tgz#75c5dae60063ee641f977e00edd3cfb2fb7af6a7"
+  integrity sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==
+  dependencies:
+    caniuse-lite "^1.0.30001449"
+    electron-to-chromium "^1.4.284"
+    node-releases "^2.0.8"
+    update-browserslist-db "^1.0.10"
+
 bser@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.1.1.tgz#e6787da20ece9d07998533cfd9de6f5c38f4bc05"
@@ -1529,6 +1539,11 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001313, caniuse-lite@^1.0.30001314:
   version "1.0.30001314"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001314.tgz#65c7f9fb7e4594fca0a333bec1d8939662377596"
   integrity sha512-0zaSO+TnCHtHJIbpLroX7nsD+vYuOVjl3uzFbJO1wMVbuveJA0RK2WcQA9ZUIOiO0/ArMiMgHJLxfEZhQiC0kw==
+
+caniuse-lite@^1.0.30001449:
+  version "1.0.30001451"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001451.tgz#2e197c698fc1373d63e1406d6607ea4617c613f1"
+  integrity sha512-XY7UbUpGRatZzoRft//5xOa69/1iGJRBlrieH6QYrkKLIFn3m7OVEJ81dSrKoy2BnKsdbX5cLrOispZNYo9v2w==
 
 cardinal@^2.1.1:
   version "2.1.1"
@@ -2137,6 +2152,11 @@ duplexer2@~0.1.0:
   integrity sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=
   dependencies:
     readable-stream "^2.0.2"
+
+electron-to-chromium@^1.4.284:
+  version "1.4.295"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.295.tgz#911d5df67542bf7554336142eb302c5ec90bba66"
+  integrity sha512-lEO94zqf1bDA3aepxwnWoHUjA8sZ+2owgcSZjYQy0+uOSEclJX0VieZC+r+wLpSxUHRd6gG32znTWmr+5iGzFw==
 
 electron-to-chromium@^1.4.76:
   version "1.4.81"
@@ -4173,6 +4193,11 @@ node-releases@^2.0.2:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.2.tgz#7139fe71e2f4f11b47d4d2986aaf8c48699e0c01"
   integrity sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==
 
+node-releases@^2.0.8:
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.10.tgz#c311ebae3b6a148c89b1813fd7c4d3c024ef537f"
+  integrity sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==
+
 nopt@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-5.0.0.tgz#530942bb58a512fccafe53fe210f13a25355dc88"
@@ -5907,6 +5932,14 @@ universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
+
+update-browserslist-db@^1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz#0f54b876545726f17d00cd9a2561e6dade943ff3"
+  integrity sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==
+  dependencies:
+    escalade "^3.1.1"
+    picocolors "^1.0.0"
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
Related: https://github.com/vercel/next.js/issues/45492

`browserlist` is using the `node-release` package for the latest Node.js release information:

https://github.com/browserslist/browserslist/blob/fc5fc088c640466df62a6b6c86154b19be3de821/index.js#L1

And `cssnano-preset-default` also requires `browserlist`:

<img width="1002" alt="image" src="https://user-images.githubusercontent.com/40715044/218330083-a6e88c8b-614c-4a28-bd2b-063ca92530c5.png">

Since the `casino-preset-simple` uses `ncc` to precompile the entire library, it effectively makes the `casino-preset-simple` never be able to get the latest Node.js release information.

The PR adds `browserlist` to the `external`, preventing the `node-release` package from being included in the dist.

The PR will also reduce the final Next.js `node_modules` footprint, since Next.js also precompiles `browserlist` (https://github.com/vercel/next.js/blob/fe8c43213df099602724bf2e2499564fcfbb1332/packages/next/taskfile.js#L602-L605), thus the PR effectively removes the duplicated `browserslist`.

----

Before the PR:

<img width="1276" alt="image" src="https://user-images.githubusercontent.com/40715044/218330299-1093c4bb-28fc-42ce-a8d5-581cd11644dd.png">

After the PR:

<img width="1278" alt="image" src="https://user-images.githubusercontent.com/40715044/218330308-d776d6bb-c748-4240-9072-1b042de1c77c.png">

The output size is being reduced by half.